### PR TITLE
Reduce the impact of UUID's generation to tests

### DIFF
--- a/chronicle-map-benchmarks/src/main/java/io/scalecube/benchmarks/storages/chronicle/ChronicleMapStorage.java
+++ b/chronicle-map-benchmarks/src/main/java/io/scalecube/benchmarks/storages/chronicle/ChronicleMapStorage.java
@@ -53,7 +53,7 @@ public class ChronicleMapStorage implements Storage<UUID, Order> {
               .entries(entriesCount)
               .maxBloatFactor(50)
               .constantKeySizeBySample(UUID.randomUUID())
-              .averageValue(new Order(UUID.randomUUID()))
+              .averageValue(new Order(0))
               .putReturnsNull(true)
               .removeReturnsNull(true)
               .keyMarshaller(new UuidMarshaller())

--- a/kafka-benchmarks/src/main/java/io/scalecube/benchmarks/kafka/reactor/ExampleService.java
+++ b/kafka-benchmarks/src/main/java/io/scalecube/benchmarks/kafka/reactor/ExampleService.java
@@ -31,6 +31,11 @@ public class ExampleService {
   private static final String TOPIC_SEND = "benchmark-topic-b";
   private static final int MAX_IN_FLIGHT = 256;
 
+  /**
+   * Run the service.
+   *
+   * @param args program args
+   */
   public static void main(String[] args) throws InterruptedException {
     KafkaSender<Integer, Message> kafkaSender = kafkaSender();
 
@@ -79,14 +84,14 @@ public class ExampleService {
   }
 
   private static Flux<SenderRecord<Integer, Message, Integer>> records() {
-    return Mono.fromCallable(
-            () -> {
-              Message message = new Message(System.currentTimeMillis());
-              int correlationMetadata = message.hashCode();
-              ProducerRecord<Integer, Message> record =
-                  new ProducerRecord<>(TOPIC_SEND, correlationMetadata, message);
-              return SenderRecord.create(record, correlationMetadata);
-            })
-        .repeat();
+    return Mono.fromCallable(ExampleService::generateSenderRecord).repeat();
+  }
+
+  private static SenderRecord<Integer, Message, Integer> generateSenderRecord() {
+    Message message = new Message(System.currentTimeMillis());
+    int correlationMetadata = message.hashCode();
+    ProducerRecord<Integer, Message> record =
+        new ProducerRecord<>(TOPIC_SEND, correlationMetadata, message);
+    return SenderRecord.create(record, correlationMetadata);
   }
 }

--- a/kafka-benchmarks/src/main/java/io/scalecube/benchmarks/kafka/reactor/example/ReactorKafkaSender.java
+++ b/kafka-benchmarks/src/main/java/io/scalecube/benchmarks/kafka/reactor/example/ReactorKafkaSender.java
@@ -23,6 +23,11 @@ public class ReactorKafkaSender {
 
   private static final int MESSAGE_COUNT = 10_000_000;
 
+  /**
+   * Run the sender.
+   *
+   * @param args program args
+   */
   public static void main(String[] args) throws InterruptedException {
     Map<String, Object> producerProps = new HashMap<>();
     producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, SERVERS);

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>io.scalecube</groupId>
     <artifactId>scalecube-parent-pom</artifactId>
-    <version>0.0.15</version>
+    <version>0.0.19</version>
   </parent>
 
   <artifactId>scalecube-third-party-benchmarks-parent</artifactId>

--- a/storage-benchmarks-common/src/main/java/io/scalecube/benchmarks/storages/common/StorageState.java
+++ b/storage-benchmarks-common/src/main/java/io/scalecube/benchmarks/storages/common/StorageState.java
@@ -59,7 +59,7 @@ public class StorageState extends BenchmarkState<StorageState> {
           .runOn(scheduler())
           .doOnNext(
               i -> {
-                Order order = new Order(uuid(i));
+                Order order = new Order(i);
                 try {
                   storage.write(order.id(), order);
                 } catch (Exception e) {

--- a/storage-benchmarks-common/src/main/java/io/scalecube/benchmarks/storages/common/WriteScenario.java
+++ b/storage-benchmarks-common/src/main/java/io/scalecube/benchmarks/storages/common/WriteScenario.java
@@ -4,7 +4,6 @@ import io.scalecube.benchmarks.BenchmarkSettings;
 import io.scalecube.benchmarks.metrics.BenchmarkTimer;
 import io.scalecube.benchmarks.storages.common.entity.Order;
 import java.time.Duration;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import reactor.core.Exceptions;

--- a/storage-benchmarks-common/src/main/java/io/scalecube/benchmarks/storages/common/WriteScenario.java
+++ b/storage-benchmarks-common/src/main/java/io/scalecube/benchmarks/storages/common/WriteScenario.java
@@ -35,7 +35,7 @@ public class WriteScenario {
 
               return iteration -> {
                 try {
-                  Order order = new Order(UUID.randomUUID());
+                  Order order = new Order(iteration);
                   BenchmarkTimer.Context writeTime = timer.time();
                   state.storage().write(order.id(), order);
                   writeTime.stop();

--- a/storage-benchmarks-common/src/main/java/io/scalecube/benchmarks/storages/common/entity/Order.java
+++ b/storage-benchmarks-common/src/main/java/io/scalecube/benchmarks/storages/common/entity/Order.java
@@ -40,14 +40,14 @@ public final class Order implements Externalizable {
   public Order() {}
 
   /**
-   * Generates a random order by the given order identifier.
+   * Generates a random order by the given order id.
    *
-   * @param orderId order identifier
+   * @param id id
    */
-  public Order(UUID orderId) {
-    id = orderId;
-    userId = UUID.randomUUID().toString();
-    instrumentInstanceId = UUID.randomUUID().toString();
+  public Order(long id) {
+    this.id = new UUID(Integer.MAX_VALUE, id);
+    userId = new UUID(0, id).toString();
+    instrumentInstanceId = new UUID(1, id).toString();
     instrumentName = "BTC";
     quantity = BigDecimal.valueOf(RANDOM.nextLong());
     remainingQuantity = BigDecimal.valueOf(RANDOM.nextLong());


### PR DESCRIPTION
Just run `io.scalecube.benchmarks.storages.chronicle.ChronicleMapStorageWriteBenchmark` of this one and current master - you should feel the difference.